### PR TITLE
LIBSEARCH-79. Small naming tweaks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Bundler/OrderedGems:
 Style/StringLiterals:
   Exclude:
     - config/puma.rb
+
 Style/PercentLiteralDelimiters:
   Exclude:
     - config/spring.rb

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>SearchumdSpecial</title>
+    <title>SearchUMDSpecial</title>
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module SearchumdSpecial
+module SearchUmdSpecial
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1


### PR DESCRIPTION
Made small naming tweaks to keep things consistent with the way
naming is done in the "searchumd" application.

https://issues.umd.edu/browse/LIBSEARCH-79