### PR TITLE
LIBSEARCH-81 Replace arxiv with archivesspace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,9 @@ gem 'quick_search-core', git: 'https://github.com/NCSU-Libraries/quick_search.gi
 
 gem 'quick_search-wikipedia_searcher'
 gem 'quick_search-open_library_searcher'
-gem 'quick_search-arxiv_searcher'
+gem 'quick_search-archives_space_searcher',
+    git: 'https://github.com/umd-lib/quick_search-archives_space_searcher.git',
+    branch: 'develop'
 gem 'quick_search-placeholder_searcher'
 
 # -END Inserted by QuickSearch-

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -27,7 +27,7 @@
 <div class="quicksearch-ga-click-tracking">
     <div class="row articles-catalog">
         <div class="small-12 medium-4 columns catalog module">
-          <%= render_module(@arxiv, 'arxiv') %>
+          <%= render_module(@archives_space, 'archives_space') %>
         </div>
         <div class="small-12 medium-4 columns catalog module">
             <%= render_module(@open_library, 'open_library') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,3 +35,5 @@ en:
     title_name: "Special and Digital Collections"
     search_form_placeholder: "Search the collections"
     module_callout: "Search for anything in our collections!"
+  archives_space_search:
+    no_results_link:

--- a/config/quick_search_config.yml
+++ b/config/quick_search_config.yml
@@ -18,11 +18,11 @@ defaults: &defaults
   #
   # See docs for more details: https://github.com/NCSU-Libraries/quick_search/blob/master/docs/configuration.md
 
-  searchers: [best_bets,arxiv,open_library,wikipedia,placeholder]
+  searchers: [best_bets,archives_space,open_library,wikipedia,placeholder]
 
   # Searchers listed in the "result type guide" bar that lists result types that were found for a given search
 
-  found_types: [arxiv,open_library,wikipedia,placeholder,placeholder,placeholder,placeholder]
+  found_types: [archives_space,open_library,wikipedia,placeholder,placeholder,placeholder,placeholder]
 
   per_page: 3
   max_per_page: 50

--- a/config/searchers/archives_space_config.yml
+++ b/config/searchers/archives_space_config.yml
@@ -1,0 +1,56 @@
+# Configuration
+#
+# Replace the following placeholders with the correct values for
+# your installation.
+#
+# search_url: The URL for performing the search
+# loaded_link: URL to the 'native' interface
+# object_types: aspace object types to return. these are mapped to Solr types:
+# field queries
+# query_params: params to be passed to Solr
+# native_query_params: params to be passed to the loaded_link.
+
+defaults: &defaults
+  search_url: '<%= ENV['ARCHIVES_SPACE_SOLR_URL'] %>'
+  loaded_link: '<%= ENV['ARCHIVES_SPACE_URL'] %>/search'
+  no_results_link: '<%= ENV['ARCHIVES_SPACE_URL'] %>'
+  object_types:
+    - subject
+    - classification
+    - accession
+    - repository
+    - resource
+    - agent
+    - digital_object
+    - archival_object
+  query_params:
+    'q.op': AND
+    q:
+      - 'publish:(true)'
+      - 'types:(pui)' 
+    fq:
+      - '-exclude_by_default:true'
+      - 'publish:true'
+    rows: 3
+    wt: 'json'
+  native_query_params:
+    op: ['']
+    q: []
+    uft8: '✓'
+    limit: ''
+    field: ['']
+    from_year: ['']
+    to_year: ['']
+    commit: 'Search' 
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+staging:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/env_example
+++ b/env_example
@@ -33,3 +33,7 @@ PROD_DATABASE_PORT=5432
 
 # Pool size
 PROD_DATABASE_POOL=10
+
+# The ArchivesSpace search endpoint
+ARCHIVES_SPACE_URL=''
+ARCHIVES_SPACE_SOLR_URL=''

--- a/env_example
+++ b/env_example
@@ -34,6 +34,9 @@ PROD_DATABASE_PORT=5432
 # Pool size
 PROD_DATABASE_POOL=10
 
+# --- config/searchers/archives_space_config
 # The ArchivesSpace search endpoint
-ARCHIVES_SPACE_URL=''
-ARCHIVES_SPACE_SOLR_URL=''
+ARCHIVES_SPACE_URL=
+
+# The ArchivesSpace Solr search endpoint
+ARCHIVES_SPACE_SOLR_URL=


### PR DESCRIPTION
This replaces the arxiv search with archivesspace.

https://issues.umd.edu/browse/LIBSEARCH-81

Note: this PR won't actually work because the search plugin hasn't been merged into master. Once that's done, we can update the Gemfile.lock.