### PR TITLE
LIBSEARCH-86. Added Fedora searcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ gem 'quick_search-core', git: 'https://github.com/umd-lib/quick_search.git', bra
 # your config/quick_search_config.yml file as well as references to them in your theme's search
 # results page template
 
-gem 'quick_search-wikipedia_searcher'
 gem 'quick_search-open_library_searcher'
 gem 'quick_search-archives_space_searcher',
     git: 'https://github.com/umd-lib/quick_search-archives_space_searcher.git',
@@ -68,6 +67,9 @@ gem 'quick_search-drum_searcher',
 gem 'quick_search-internet_archive_searcher',
     git: 'https://github.com/umd-lib/quick_search-internet_archive_searcher',
     branch: 'develop'
+
+gem 'quick_search-fedora_searcher',
+    git: 'https://github.com/umd-lib/quick_search-fedora_searcher.git', branch: 'develop'
 
 # -END Inserted by QuickSearch-
 

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -33,7 +33,7 @@
             <%= render_module(@DRUM, 'DRUM') %>
         </div>
         <div class="small-12 medium-4 columns catalog module">
-            <%= render_module(@wikipedia, 'wikipedia') %>
+            <%= render_module(@fedora, 'fedora') %>
         </div>
         <hr>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,9 @@ en:
   archives_space_search:
     # Configure no_results_link in config/searchers/archives_space_config.yml
     no_results_link:
+  fedora_search:
+    # Configure no_results_link in config/searchers/fedora_config.yml
+    no_results_link:
   DRUM_search:
     # Configure no_results_link in config/searchers/drum_config.yml
     no_results_link:

--- a/config/quick_search_config.yml
+++ b/config/quick_search_config.yml
@@ -18,8 +18,8 @@ defaults: &defaults
   #
   # See docs for more details: https://github.com/NCSU-Libraries/quick_search/blob/master/docs/configuration.md
 
-  searchers: [best_bets,archives_space,DRUM,wikipedia,internet_archive, placeholder]
-  found_types: [archives_space,DRUM,wikipedia,internet_archive,placeholder,placeholder,placeholder]
+  searchers: [best_bets,archives_space,DRUM,fedora,internet_archive,placeholder]
+  found_types: [archives_space,DRUM,fedora,internet_archive,placeholder,placeholder,placeholder]
 
   per_page: 3
   max_per_page: 50

--- a/config/searchers/fedora_config.yml
+++ b/config/searchers/fedora_config.yml
@@ -1,0 +1,26 @@
+# Configuration
+#
+# Replace the following placeholders with the correct values for
+# your installation.
+#
+# <SEARCH_URL>: The URL for performing the search
+# <QUERY_PARAMS>: Any HTTP query parameters that should be included in the search
+# <WEBSITE_SEARCH_URL>: The URL for the website search page (with query parameter)
+
+defaults: &defaults
+  search_url: "<%= ENV['FEDORA_HIPPO_SITE_URL'] %><%= ENV['FEDORA_HIPPO_SITE_SEARCH_PATH'] %>/json"
+  query_params: '?query='
+  no_results_link: "<%= ENV['FEDORA_HIPPO_SITE_URL'] %><%= ENV['FEDORA_HIPPO_SITE_SEARCH_PATH'] %>"
+  loaded_link: "<%= ENV['FEDORA_HIPPO_SITE_URL'] %><%= ENV['FEDORA_HIPPO_SITE_SEARCH_PATH'] %>"
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+staging:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/env_example
+++ b/env_example
@@ -44,3 +44,10 @@ ARCHIVES_SPACE_SOLR_URL=
 # --- config/searchers/drum_config.yml
 # The URL for the DRUM site
 DRUM_SITE_URL=
+
+# --- config/searchers/fedora_config.yml
+# The base URL for performing Fedora searches using the Hippo CMS
+FEDORA_HIPPO_SITE_URL=
+
+# The URL path to native search interface
+FEDORA_HIPPO_SITE_SEARCH_PATH=searchnew


### PR DESCRIPTION
Initial implementation, replacing "Wikipedia" searcher with "Fedora"
searcher.

https://issues.umd.edu/browse/LIBSEARCH-86