### PR TITLE
LIBSEARCH-82. Added DRUM searcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,9 +52,11 @@ gem 'quick_search-core', git: 'https://github.com/NCSU-Libraries/quick_search.gi
 # results page template
 
 gem 'quick_search-wikipedia_searcher'
-gem 'quick_search-open_library_searcher'
 gem 'quick_search-arxiv_searcher'
 gem 'quick_search-placeholder_searcher'
+
+gem 'quick_search-drum_searcher',
+    git: 'https://github.com/umd-lib/quick_search-drum_searcher.git', branch: 'develop'
 
 # -END Inserted by QuickSearch-
 

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -30,7 +30,7 @@
           <%= render_module(@arxiv, 'arxiv') %>
         </div>
         <div class="small-12 medium-4 columns catalog module">
-            <%= render_module(@open_library, 'open_library') %>
+            <%= render_module(@DRUM, 'DRUM') %>
         </div>
         <div class="small-12 medium-4 columns catalog module">
             <%= render_module(@wikipedia, 'wikipedia') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,3 +35,7 @@ en:
     title_name: "Special and Digital Collections"
     search_form_placeholder: "Search the collections"
     module_callout: "Search for anything in our collections!"
+
+  DRUM_search:
+    # Configure no_results_link in config/searchers/drum_config.yml
+    no_results_link:

--- a/config/quick_search_config.yml
+++ b/config/quick_search_config.yml
@@ -18,11 +18,11 @@ defaults: &defaults
   #
   # See docs for more details: https://github.com/NCSU-Libraries/quick_search/blob/master/docs/configuration.md
 
-  searchers: [best_bets,arxiv,open_library,wikipedia,placeholder]
+  searchers: [best_bets,arxiv,DRUM,wikipedia,placeholder]
 
   # Searchers listed in the "result type guide" bar that lists result types that were found for a given search
 
-  found_types: [arxiv,open_library,wikipedia,placeholder,placeholder,placeholder,placeholder]
+  found_types: [arxiv,DRUM,wikipedia,placeholder,placeholder,placeholder,placeholder]
 
   per_page: 3
   max_per_page: 50

--- a/config/searchers/drum_config.yml
+++ b/config/searchers/drum_config.yml
@@ -1,0 +1,28 @@
+# Configuration
+#
+# Replace the following placeholders with the correct values for
+# your installation.
+#
+# search_url: The URL for performing the search
+# native_url: Link to the 'native'/human interface
+# query_params => rpp: Number of results to display
+
+defaults: &defaults
+  search_url: '<%= ENV['DRUM_SITE_URL'] %>open-search/discover'
+  native_url: '<%= ENV['DRUM_SITE_URL'] %>discover'
+  no_results_link: '<%= ENV['DRUM_SITE_URL'] %>discover'
+  # Query params should be listed in "hash" format
+  query_params:
+    query: ''
+    rpp: 3
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+staging:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/env_example
+++ b/env_example
@@ -33,3 +33,7 @@ PROD_DATABASE_PORT=5432
 
 # Pool size
 PROD_DATABASE_POOL=10
+
+# --- config/searchers/drum_config.yml
+# The URL for the DRUM site
+DRUM_SITE_URL=


### PR DESCRIPTION
Initial implementation, replacing "OpenLibrary" searcher with "DRUM"
searcher.

https://issues.umd.edu/browse/LIBSEARCH-82